### PR TITLE
change tabs to spaces when exporting BIDS

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -515,8 +515,13 @@ int nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],struc
         free(vx);
         return numFinalADC;
     }
-    for (int i = 0; i < (numDti-1); i++)
-        fprintf(fp, "%g\t", vx[i].V[0]);
+    for (int i = 0; i < (numDti-1); i++) {
+				if (opts.isCreateBIDS) {
+        		fprintf(fp, "%g ", vx[i].V[0]);
+				} else {
+						fprintf(fp, "%g\t", vx[i].V[0]);
+				}
+		}
     fprintf(fp, "%g\n", vx[numDti-1].V[0]);
     fclose(fp);
     strcpy(txtname,pathoutname);
@@ -528,8 +533,13 @@ int nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],struc
         return numFinalADC;
     }
     for (int v = 1; v < 4; v++) {
-        for (int i = 0; i < (numDti-1); i++)
-            fprintf(fp, "%g\t", vx[i].V[v]);
+        for (int i = 0; i < (numDti-1); i++) {
+						if (opts.isCreateBIDS) {
+            	fprintf(fp, "%g ", vx[i].V[v]);
+						} else {
+							fprintf(fp, "%g\t", vx[i].V[v]);
+						}
+				}
         fprintf(fp, "%g\n", vx[numDti-1].V[v]);
     }
     fclose(fp);

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -516,11 +516,11 @@ int nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],struc
         return numFinalADC;
     }
     for (int i = 0; i < (numDti-1); i++) {
-				if (opts.isCreateBIDS) {
-        		fprintf(fp, "%g ", vx[i].V[0]);
-				} else {
-						fprintf(fp, "%g\t", vx[i].V[0]);
-				}
+        if (opts.isCreateBIDS) {
+            fprintf(fp, "%g ", vx[i].V[0]);
+        } else {
+            fprintf(fp, "%g\t", vx[i].V[0]);
+        }
 		}
     fprintf(fp, "%g\n", vx[numDti-1].V[0]);
     fclose(fp);
@@ -534,11 +534,11 @@ int nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],struc
     }
     for (int v = 1; v < 4; v++) {
         for (int i = 0; i < (numDti-1); i++) {
-						if (opts.isCreateBIDS) {
-            	fprintf(fp, "%g ", vx[i].V[v]);
-						} else {
-							fprintf(fp, "%g\t", vx[i].V[v]);
-						}
+            if (opts.isCreateBIDS) {
+                fprintf(fp, "%g ", vx[i].V[v]);
+            } else {
+                fprintf(fp, "%g\t", vx[i].V[v]);
+            }
 				}
         fprintf(fp, "%g\n", vx[numDti-1].V[v]);
     }

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -539,7 +539,7 @@ int nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],struc
             } else {
                 fprintf(fp, "%g\t", vx[i].V[v]);
             }
-				}
+        }
         fprintf(fp, "%g\n", vx[numDti-1].V[v]);
     }
     fclose(fp);


### PR DESCRIPTION
.bval/.bvec files use spaces instead of tabs in BIDS, when the user asks for the sidecar JSON file we should switch the delimiter assuming that .bval/.bvec files should also be BIDS compatible.

This patch does not influence the format of .bvec/.bval files if the -b flag is not used so it should not break any backwards compatibility.