### PR TITLE
Acquisition Number

### DIFF
--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -59,7 +59,7 @@ void showHelp(const char * argv[], struct TDCMopts opts) {
     printf("usage: %s [options] <in_folder>\n", cstr);
     printf(" Options :\n");
     printf("  -b : BIDS sidecar (y/n, default n)\n");
-    printf("  -f : filename (%%a=antenna  (coil) number %%c=comments %%d=description %%e echo number %%f=folder name %%i ID of patient %%m=manufacturer %%n=name of patient %%p=protocol, %%q=sequence number %%s=series number, %%t=time, %%z sequence name; default '%s')\n",opts.filename);
+    printf("  -f : filename (%%a=antenna  (coil) number, %%c=comments, %%d=description, %%e echo number, %%f=folder name, %%i ID of patient, %%m=manufacturer, %%n=name of patient, %%p=protocol, %%q=sequence number, %%s=series number, %%t=time, %%u=acquisition number, %%z sequence name; default '%s')\n",opts.filename);
     printf("  -h : show help\n");
     printf("  -m : merge 2D slices from same series regardless of study time, echo, coil, orientation, etc. (y/n, default n)\n");
     printf("  -o : output directory (omit to save to input folder)\n");

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -739,6 +739,10 @@ int nii_createFilename(struct TDICOMdata dcm, char * niiFilename, struct TDCMopt
                 sprintf(newstr, "%0.0f", dcm.dateTime);
                 strcat (outname,newstr);
             }
+            if (f == 'U') {
+              sprintf(newstr, "%d", dcm.acquNum);
+              strcat (outname,newstr);
+            }
             if (f == 'Z')
                 strcat (outname,dcm.sequenceName);
             start = pos + 1;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1589,7 +1589,8 @@ bool isSameSet (struct TDICOMdata d1, struct TDICOMdata d2, bool isForceStackSam
     //returns true if d1 and d2 should be stacked together as a single output
     if (!d1.isValid) return false;
     if (!d2.isValid) return false;
-    if  (d1.seriesNum != d2.seriesNum) return false;
+    if (d1.seriesNum != d2.seriesNum) return false;
+    if (d1.acquNum != d2.acquNum) return false;
     if ((d1.bitsAllocated != d2.bitsAllocated) || (d1.xyzDim[1] != d2.xyzDim[1]) || (d1.xyzDim[2] != d2.xyzDim[2]) || (d1.xyzDim[3] != d2.xyzDim[3]) ) {
         if (!warnings->bitDepthVaries)
         	printf("slices not stacked: dimensions or bit-depth varies\n");


### PR DESCRIPTION
The original dcm2nii properly segmented images having different acquisition numbers. Added this behavior into dcm2niix, and added acquisition number as a possible filename element.